### PR TITLE
Fix the site name

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -17,7 +17,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = "Software"
+project = '地震"学"软件'
 author = "seismo-learn"
 copyright = f"2020, {author}."
 


### PR DESCRIPTION
Change "Software" to '地震"学"软件':

![image](https://user-images.githubusercontent.com/3974108/102441668-bcf7f600-3ff0-11eb-8398-adabf12c0d2b.png)

Looks better, right?