### PR TITLE
Continuous documentation deployment for preview

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           body: |
             This comment was written by the Continuous Documentation bot!
 
-            - **Preview**: http://seismo-learn.org/sitepreview/${{ github.repository }}/${{ github.head_ref }}
+            - **Preview**: https://seismo-learn.org/sitepreview/${{ github.repository }}/${{ github.head_ref }}
             - **Commit hash**: ${{ github.event.pull_request.head.sha }}
 
       - name: Update comment
@@ -87,5 +87,5 @@ jobs:
           body: |
             This comment was written by the Continuous Documentation bot!
 
-            - **Preview**: http://seismo-learn.org/sitepreview/${{ github.repository }}/${{ github.head_ref }}
+            - **Preview**: https://seismo-learn.org/sitepreview/${{ github.repository }}/${{ github.head_ref }}
             - **Commit hash**: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,11 @@ jobs:
       - name: Build sphinx document
         run: make dirhtml
 
-      - name: Deploy
+      - name: Deploy documentation
         if: success() && github.event_name == 'push'
-        uses: peaceiris/actions-gh-pages@v3
+        # peaceiris/actions-gh-pages@v3.7.3
+        # Don't use tags: https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
+        uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/dirhtml
@@ -37,3 +39,53 @@ jobs:
           force_orphan: true
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Deploy for preview
+        if: success() && github.event_name == 'pull_request'
+        # peaceiris/actions-gh-pages@v3.7.3
+        # Don't use tags: https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
+        uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501
+        with:
+          # personal token can be generated at https://github.com/settings/tokens,
+          # and added to https://github.com/organizations/seismo-learn/settings/secrets/actions
+          personal_token: ${{ secrets.TOKEN_DOCUMENT_DEPLOY }}
+          publish_dir: ./build/dirhtml
+          destination_dir: ${{ github.repository }}/${{ github.head_ref }}
+          external_repository: seismo-learn/sitepreview
+          keep_files: false
+          allow_empty_commit: true
+          force_orphan: false
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Find Comment
+        if: success() && github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: This comment was written by the Continuous Documentation bot!
+
+      - name: Create comment
+        if: ${{ steps.fc.outputs.comment-id == 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            This comment was written by the Continuous Documentation bot!
+
+            - **Preview**: http://seismo-learn.org/sitepreview/${{ github.repository }}/${{ github.head_ref }}
+            - **Commit hash**: ${{ github.event.pull_request.head.sha }}
+
+      - name: Update comment
+        if: ${{ steps.fc.outputs.comment-id != 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            This comment was written by the Continuous Documentation bot!
+
+            - **Preview**: http://seismo-learn.org/sitepreview/${{ github.repository }}/${{ github.head_ref }}
+            - **Commit hash**: ${{ github.event.pull_request.head.sha }}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "github": {
-    "silent": true
-  }
-}


### PR DESCRIPTION
Vercel is powerful but is no longer free. This PR removes vercel.json and add new steps for documentation preview.

How does it works:

1. The generated documentation is pushed to the gh-pages branch of the repository https://github.com/seismo-learn/sitepreview. So we can access the documentation by visiting 

http://seismo-learn.org/sitepreview/seismo-learn/<repository_name>/<branch_name>

2. Create a comment, showing the documentation preview URL and the latest commit hash
3. If there was a comment, update it with the latest commit hash