### PR TITLE
Cross-reference to external projects

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -40,6 +40,7 @@ rst_prolog = """
 # ones.
 extensions = [
     "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
     "sphinx_cjkspace.cjkspace",
 ]
 
@@ -57,6 +58,14 @@ language = "zh_CN"
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
+
+# Cross-refering other projects
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
+intersphinx_mapping = {
+    "seis": ("https://seismo-learn.org/seismology/", None),
+    "seis101": ("https://seismo-learn.org/seismology101/", None),
+    "software": ("https://seismo-learn.org/software/", None),
+}
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/source/gmt/index.rst
+++ b/source/gmt/index.rst
@@ -19,5 +19,5 @@ GMT，全称 Generic Mapping Tools，中文一般译为“通用制图工具”�
 
 .. note::
 
-   若选择编译源码安装 GMT，我们建议将 GMT 安装到 :file:`~/opt/` 目录下，详情见
-   `《软件安装实践经验》 <https://seismo-learn.org/seismology101/best-practices/software-installation/>`__。
+   若选择编译源码安装 GMT，我们建议将 GMT 安装到 :file:`~/opt/` 目录下，
+   详情见\ :doc:`《软件安装实践经验》<seis101:best-practices/software-installation>`。

--- a/source/sac/index.rst
+++ b/source/sac/index.rst
@@ -21,5 +21,5 @@ SAC，全称 Seismic Analysis Code，是天然地震学领域使用最广泛的�
 
 .. note::
 
-   我们建议将 SAC 安装到 :file:`~/opt/` 目录下，详情见
-   `《软件安装实践经验》 <https://seismo-learn.org/seismology101/best-practices/software-installation/>`__。
+   我们建议将 SAC 安装到 :file:`~/opt/` 目录下，
+   详情见\ :doc:`《软件安装实践经验》<seis101:best-practices/software-installation>`。


### PR DESCRIPTION
This PR enables cross-reference to external projects.
See https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
for full documentation.

Below are 4 different ways to cross-reference documents of an external
project.

```
:doc:`best-practices/software-installation`
:doc:`Any Text <best-practices/software-installation>`
:doc:`seis101:best-practices/software-installation`
:doc:`Any Text <seis101:best-practices/software-installation>`
```

For option 1 and 2, Sphinx will lookup the document in the current
project first, if not found, they lookup in external projects.

For option 3 and 4, Sphinx will force lookup the document in external
projects.

I'm in favor of option 3 and 4. As we're working on multiple projects,
if we have the same file name `best-practices/software-installation.rst`
in multiple projects, Sphinx may link to the wrong one.
