### PR TITLE
Fix failures on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
+          brew upgrade gcc
           brew install gfortran
         if: matrix.os == 'macos-11.0'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          brew update
           brew install gfortran
         if: matrix.os == 'macos-11.0'
 


### PR DESCRIPTION
Need to run `brew update` and `brew upgrade gcc` to have `gfortran` installed.