### PR TITLE
Allow running CI jobs from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: CI
 
 # Run for PRs and the main branch
 on:
+  pull_request:
   pull_request_target:
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: CI
 
 # Run for PRs and the main branch
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: CI
 
 # Run for PRs and the main branch
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - main

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,7 +2,7 @@ name: Label Pull Request
 
 # Run for PRs
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   triage:


### PR DESCRIPTION
The solution comes from
https://github.com/actions/labeler/issues/36#issuecomment-670967903,
and
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/.

Hopefully it fixes #160.
