### PR TITLE
Fix SOD and TauP author links

### DIFF
--- a/source/sod/index.rst
+++ b/source/sod/index.rst
@@ -5,7 +5,7 @@ SOD
 :主页: http://www.seis.sc.edu/sod/
 :源码地址: https://github.com/crotwell/sod
 :官方文档: http://www.seis.sc.edu/sod/
-:作者: `Philip Crotwell <https://sc.edu/study/colleges_schools/artsandsciences/earth_ocean_and_environment/our_people/directory/crotwell_philip.php>`__
+:作者: `Philip Crotwell <https://github.com/crotwell>`__
 :最新版本: v3.2.10 (2020-04-01)
 :适用平台: Linux、macOS、Windows
 :编程语言: Java

--- a/source/taup/index.rst
+++ b/source/taup/index.rst
@@ -5,7 +5,7 @@ TauP
 :主页: https://www.seis.sc.edu/taup/
 :源码地址: https://github.com/crotwell/TauP
 :官方文档: http://www.seis.sc.edu/downloads/TauP/taup.pdf
-:作者: `Philip Crotwell <https://sc.edu/study/colleges_schools/artsandsciences/earth_ocean_and_environment/our_people/directory/crotwell_philip.php>`__、 `Thomas J. Owens <https://sc.edu/study/colleges_schools/artsandsciences/earth_ocean_and_environment/our_people/directory/owens_thomas.php>`__
+:作者: `Philip Crotwell <https://github.com/crotwell>`__\、Thomas J. Owens
 :最新版本: v2.4.5 (2017-11-02)
 :适用平台: Linux、macOS、Windows
 :编程语言: Java


### PR DESCRIPTION
**Description of proposed changes**

The old links work, but lychee can't access them. 

Closes #196.

**PRs for new software/tutorials**

- [ ] Software metadata is complete
- [ ] The "last updated date" in the metadata page is up-to-date
- [ ] All links work
- [ ] You're listed as the author(s) in the metadata page
- [ ] Anyone who have made significant contributions (e.g., review) to
      the tutorials are listed in the meteda page
- [ ] Add a test to weekly CI jobs

**PRs for bugs/improvements**

- [ ] You're listed as the proofreader in the metadata page
