### PR TITLE
Test installation of TauP 2.5.0

### DIFF
--- a/tests/test-taup.sh
+++ b/tests/test-taup.sh
@@ -3,7 +3,7 @@
 set -e -x
 
 # install
-version="2.4.5"
+version="2.5.0"
 wget http://www.seis.sc.edu/downloads/TauP/TauP-${version}.tgz
 tar -xvf TauP-${version}.tgz
 mkdir -p ${HOME}/opt/
@@ -11,7 +11,7 @@ mv TauP-${version} ~/opt/
 export PATH=${HOME}/opt/TauP-${version}/bin:${PATH}
 
 # test
-[ "$(taup_time --version)" == "edu.sc.seis:TauP:${version} Thu Nov 02 15:25:47 EDT 2017" ]
+[ "$(taup --version)" == "edu.sc.seis:TauP:${version} 2021-03-17T19:52:47Z (665 6b41bfa)"
 
 # cleanup
 rm -r TauP-${version}.tgz


### PR DESCRIPTION
Update the test script to make sure TauP 2.5.0 works.
