### PR TITLE
Add a new tutorial for correcting instrument responses

### DIFF
--- a/source/_toc.yml
+++ b/source/_toc.yml
@@ -21,6 +21,7 @@ parts:
       sections:
         - file: obspy/intro
         - file: obspy/install
+        - file: obspy/instrument-response
     - file: sod/index
       sections:
         - file: sod/intro

--- a/source/obspy/instrument-response.md
+++ b/source/obspy/instrument-response.md
@@ -1,0 +1,17 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.0
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# 仪器响应
+
+- 本节贡献者: {{田冬冬}}（作者）、{{姚家园}}（审稿）
+- 最近更新日期: 2023-05-11


### PR DESCRIPTION
There are many different ways to correct and apply instrument responses in ObsPy, mainly depending on the types of the instrument responses (e.g., ObsPy's Inventory, RESP file, SAC PZ file, Poles and Zeros). This tutorial will try to cover most of these cases.

This PR is the first PR to add a "empty" section. More tutorials will be added in separate PRs (e.g., https://github.com/seismo-learn/software/pull/281, https://github.com/seismo-learn/software/pull/280).